### PR TITLE
docs: document pre-populated payload pattern for dev restarts

### DIFF
--- a/docs/operation/SOP/PM.SH.1/PM.SH.1-ManualPipelineExecution.md
+++ b/docs/operation/SOP/PM.SH.1/PM.SH.1-ManualPipelineExecution.md
@@ -53,7 +53,16 @@ For convenience, we provide a shell script that generates and optionally submits
 Bypassing populateDraftData
 --------------------------------------------------------------------------------
 
-In some cases `populateDraftData` cannot complete — for example when libraries have no
+> **Dev environment note:** Libraries analysed in dev that originate from prod upstream
+> runs (dragen, oncoanalyser) will typically have no fastq sets registered in the dev
+> metadata service. This is expected - the raw sequencing data does not exist in dev,
+> only the derived analysis outputs. This causes `populateDraftData` to fail with:
+> ```
+> ValueError: Expected exactly one current fastq set for library <id>, found 0
+> ```
+> The bypass described below is the standard workaround for this scenario.
+
+In some cases `populateDraftData` cannot complete - for example when libraries have no
 current fastq set registered in the metadata service (common when restarting in dev
 from upstream runs that were produced in prod).
 
@@ -102,7 +111,7 @@ workaround.
    }
    ```
 
-3. Run the script — the portalRunId is extracted automatically from `engineParameters.outputUri`:
+3. Run the script - the portalRunId is extracted automatically from `engineParameters.outputUri`:
    ```bash
    bash generate-WRU-draft.sh <tumor_library_id> <normal_library_id> \
      --comment 'Restart - bypass fastq lookup' \
@@ -112,7 +121,7 @@ workaround.
    ```
 
    > **Note:** do not pass `--output-uri-prefix`, `--logs-uri-prefix`, or
-   > `--cache-uri-prefix` when using this pattern — those flags would override the
+   > `--cache-uri-prefix` when using this pattern - those flags would override the
    > URIs supplied in `--input-data`.
 
 

--- a/docs/operation/SOP/PM.SH.1/PM.SH.1-ManualPipelineExecution.md
+++ b/docs/operation/SOP/PM.SH.1/PM.SH.1-ManualPipelineExecution.md
@@ -7,7 +7,7 @@ Table of Contents
 - [Introduction](#introduction)
 - [Requirements](#requirements)
 - [Procedure](#procedure)
-- [Bypassing populateDraftData](#bypassing-populatedraftdata)
+- [Pre-populating draft data](#pre-populating-draft-data)
 - [Confirmation](#confirmation)
 
 
@@ -50,7 +50,7 @@ For convenience, we provide a shell script that generates and optionally submits
   - You can have the script save the output json file by using the `--save-draft-payload` method.
 
 
-Bypassing populateDraftData
+Pre-populating draft data
 --------------------------------------------------------------------------------
 
 > **Dev environment note:** Libraries analysed in dev that originate from prod upstream
@@ -60,7 +60,7 @@ Bypassing populateDraftData
 > ```
 > ValueError: Expected exactly one current fastq set for library <id>, found 0
 > ```
-> The bypass described below is the standard workaround for this scenario.
+> The pattern described below is the standard approach for this scenario.
 
 In some cases `populateDraftData` cannot complete - for example when libraries have no
 current fastq set registered in the metadata service (common when restarting in dev
@@ -69,8 +69,7 @@ from upstream runs that were produced in prod).
 `populateDraftData` validates the incoming payload first: if it already satisfies the
 [complete-data-draft-schema.json](../../../../app/event-schemas/complete-data-draft-schema.json)
 (`tags` + `inputs` + `engineParameters`), it exits immediately without performing any
-lookups. Providing a complete payload via `--input-data` is therefore the recommended
-workaround.
+lookups. Providing a complete payload via `--input-data` is therefore the recommended approach.
 
 **Steps:**
 
@@ -114,7 +113,7 @@ workaround.
 3. Run the script - the portalRunId is extracted automatically from `engineParameters.outputUri`:
    ```bash
    bash generate-WRU-draft.sh <tumor_library_id> <normal_library_id> \
-     --comment 'Restart - bypass fastq lookup' \
+     --comment 'Restart - pre-populated inputs' \
      --input-data input_data.json \
      --workflow-version <version> \
      --code-version <code_version>

--- a/docs/operation/SOP/PM.SH.1/PM.SH.1-ManualPipelineExecution.md
+++ b/docs/operation/SOP/PM.SH.1/PM.SH.1-ManualPipelineExecution.md
@@ -69,17 +69,14 @@ from upstream runs that were produced in prod).
 `populateDraftData` validates the incoming payload first: if it already satisfies the
 [complete-data-draft-schema.json](../../../../app/event-schemas/complete-data-draft-schema.json)
 (`tags` + `inputs` + `engineParameters`), it exits immediately without performing any
-lookups. Providing a complete payload via `--input-data` is therefore the recommended approach.
+lookups. The recommended approach is to provide `tags`, `inputs`, and the ICA identifiers
+(`projectId` + `pipelineId`) via `--input-data`, and let the script generate the URI fields
+via the prefix flags. The script merges both, producing a complete payload without requiring
+a pre-generated portalRunId.
 
 **Steps:**
 
-1. Generate a portalRunId:
-   ```bash
-   PORTAL_RUN_ID="$(date -u +'%Y%m%d')$(openssl rand -hex 4)"
-   ```
-
-2. Build an `input_data.json` containing all required schema fields, using
-   `$PORTAL_RUN_ID` in the `engineParameters` URIs:
+1. Build an `input_data.json` with `tags`, `inputs`, and the ICA identifiers:
    ```json
    {
      "tags": {
@@ -102,26 +99,22 @@ lookups. Providing a complete payload via `--input-data` is therefore the recomm
      },
      "engineParameters": {
        "projectId": "<icav2_project_id>",
-       "pipelineId": "<icav2_pipeline_id>",
-       "outputUri": "s3://.../analysis/sash/<PORTAL_RUN_ID>/",
-       "logsUri": "s3://.../logs/sash/<PORTAL_RUN_ID>/",
-       "cacheUri": "s3://.../cache/sash/<PORTAL_RUN_ID>/"
+       "pipelineId": "<icav2_pipeline_id>"
      }
    }
    ```
 
-3. Run the script - the portalRunId is extracted automatically from `engineParameters.outputUri`:
+2. Run the script with prefix flags - the script auto-generates the portalRunId and builds the full URIs:
    ```bash
    bash generate-WRU-draft.sh <tumor_library_id> <normal_library_id> \
-     --comment 'Restart - pre-populated inputs' \
+     --comment 'Restart in dev - pre-populated inputs' \
      --input-data input_data.json \
+     --output-uri-prefix s3://.../analysis/sash/ \
+     --logs-uri-prefix s3://.../logs/sash/ \
+     --cache-uri-prefix s3://.../cache/sash/ \
      --workflow-version <version> \
      --code-version <code_version>
    ```
-
-   > **Note:** do not pass `--output-uri-prefix`, `--logs-uri-prefix`, or
-   > `--cache-uri-prefix` when using this pattern - those flags would override the
-   > URIs supplied in `--input-data`.
 
 
 Confirmation

--- a/docs/operation/SOP/PM.SH.1/PM.SH.1-ManualPipelineExecution.md
+++ b/docs/operation/SOP/PM.SH.1/PM.SH.1-ManualPipelineExecution.md
@@ -1,12 +1,13 @@
 Manual Pipeline Execution
 ================================================================================
-- Version: 2026.03.05
+- Version: 2026.04.20
 - Contact: Alexis Lucattini, [alexisl@unimelb.edu.au](mailto:alexisl@unimelb.edu.au)
 
 Table of Contents
 - [Introduction](#introduction)
 - [Requirements](#requirements)
 - [Procedure](#procedure)
+- [Bypassing populateDraftData](#bypassing-populatedraftdata)
 - [Confirmation](#confirmation)
 
 
@@ -47,6 +48,72 @@ For convenience, we provide a shell script that generates and optionally submits
 - The script should produce the JSON output of the DRAFT event that can be inspected to double check that reflects the intended request
   - Take note of the generated `workflowRunName` or `portalRunId` and the URL to the OrcaBus Portal view of the workflow.
   - You can have the script save the output json file by using the `--save-draft-payload` method.
+
+
+Bypassing populateDraftData
+--------------------------------------------------------------------------------
+
+In some cases `populateDraftData` cannot complete — for example when libraries have no
+current fastq set registered in the metadata service (common when restarting in dev
+from upstream runs that were produced in prod).
+
+`populateDraftData` validates the incoming payload first: if it already satisfies the
+[complete-data-draft-schema.json](../../../../app/event-schemas/complete-data-draft-schema.json)
+(`tags` + `inputs` + `engineParameters`), it exits immediately without performing any
+lookups. Providing a complete payload via `--input-data` is therefore the recommended
+workaround.
+
+**Steps:**
+
+1. Generate a portalRunId:
+   ```bash
+   PORTAL_RUN_ID="$(date -u +'%Y%m%d')$(openssl rand -hex 4)"
+   ```
+
+2. Build an `input_data.json` containing all required schema fields, using
+   `$PORTAL_RUN_ID` in the `engineParameters` URIs:
+   ```json
+   {
+     "tags": {
+       "libraryId": "<normal_library_id>",
+       "subjectId": "<subject_id>",
+       "individualId": "<individual_id>",
+       "fastqRgidList": [],
+       "tumorLibraryId": "<tumor_library_id>",
+       "tumorFastqRgidList": []
+     },
+     "inputs": {
+       "groupId": "<tumor>__<normal>",
+       "subjectId": "<tumor>__<normal>",
+       "tumorDnaSampleId": "<tumor_library_id>",
+       "normalDnaSampleId": "<normal_library_id>",
+       "dragenSomaticDir": "s3://...",
+       "dragenGermlineDir": "s3://...",
+       "oncoanalyserDnaDir": "s3://...",
+       "refDataPath": "s3://reference-data-.../refdata/sash/<version>/"
+     },
+     "engineParameters": {
+       "projectId": "<icav2_project_id>",
+       "pipelineId": "<icav2_pipeline_id>",
+       "outputUri": "s3://.../analysis/sash/<PORTAL_RUN_ID>/",
+       "logsUri": "s3://.../logs/sash/<PORTAL_RUN_ID>/",
+       "cacheUri": "s3://.../cache/sash/<PORTAL_RUN_ID>/"
+     }
+   }
+   ```
+
+3. Run the script — the portalRunId is extracted automatically from `engineParameters.outputUri`:
+   ```bash
+   bash generate-WRU-draft.sh <tumor_library_id> <normal_library_id> \
+     --comment 'Restart - bypass fastq lookup' \
+     --input-data input_data.json \
+     --workflow-version <version> \
+     --code-version <code_version>
+   ```
+
+   > **Note:** do not pass `--output-uri-prefix`, `--logs-uri-prefix`, or
+   > `--cache-uri-prefix` when using this pattern — those flags would override the
+   > URIs supplied in `--input-data`.
 
 
 Confirmation

--- a/docs/operation/SOP/PM.SH.1/generate-WRU-draft.sh
+++ b/docs/operation/SOP/PM.SH.1/generate-WRU-draft.sh
@@ -95,12 +95,12 @@ The populate draft data service will try to auto-populate inputs based on the in
   }
 }
 
-2. Full schema bypass - skip populateDraftData entirely by providing a payload that
+2. Full payload - skip populateDraftData lookups by providing a payload that already
    satisfies the complete-data-draft-schema.json (tags + inputs + engineParameters).
    populateDraftData validates the payload first; if it is already complete it exits
    immediately without performing any lookups (including the fastq RGID lookup).
    Use this when libraries have no fastq sets registered in the metadata service
-   (e.g. restarting in dev from prod upstream runs).
+   (e.g. restarting in dev from prod upstream runs where raw data does not exist in dev).
 
    Generate a portalRunId first, embed it in the engineParameters URIs, then pass
    the file to --input-data. The script extracts the portalRunId automatically from
@@ -109,7 +109,7 @@ The populate draft data service will try to auto-populate inputs based on the in
    PORTAL_RUN_ID=\"\$(date -u +'%Y%m%d')\$(openssl rand -hex 4)\"
    # build input_data.json with all schema fields and \$PORTAL_RUN_ID in URIs, then:
    bash generate-WRU-draft.sh tumor_lib normal_lib \\
-     --comment 'Restart - bypass fastq lookup' \\
+     --comment 'Restart - pre-populated inputs' \\
      --input-data input_data.json \\
      --workflow-version <version> --code-version <code>
 

--- a/docs/operation/SOP/PM.SH.1/generate-WRU-draft.sh
+++ b/docs/operation/SOP/PM.SH.1/generate-WRU-draft.sh
@@ -69,7 +69,6 @@ generate-WRU-draft.sh (library_id)...
                       [--workflow-version <workflow_version>]
                       [--code-version <code_version>]
                       [--input-data <input_data_path>]
-                      [--portal-run-id <portal_run_id>]
 
 Description:
 Run this script to generate a draft WorkflowRunUpdate event for the specified library IDs.
@@ -133,10 +132,6 @@ Keyword arguments:
   --input-data=<input_data_file>                (Optional) Add existing input data to the data section of the payload.
                                                            This might be used to explicitly set input files
                                                            See input data note for more information.
-  --portal-run-id=<portal_run_id>              (Optional) Override the auto-generated portal run ID.
-                                                           If --input-data contains engineParameters.outputUri, the
-                                                           portal run ID is extracted from it automatically and this
-                                                           flag is not needed.
 
 Environment:
   PORTAL_TOKEN: (Required) Your personal portal token from https://portal.${hostname}/
@@ -542,15 +537,6 @@ while [[ $# -gt 0 ]]; do
       INPUT_DATA_FILE="${1#*=}"
       shift
       ;;
-    # Portal run id override
-    --portal-run-id)
-      portal_run_id="$2"
-      shift 2
-      ;;
-    --portal-run-id=*)
-      portal_run_id="${1#*=}"
-      shift
-      ;;
     # Positional arguments (library IDs)
     *)
       LIBRARY_ID_ARRAY+=("$1")
@@ -651,27 +637,8 @@ if ! email_address="$(get_email_from_portal_token)"; then
   exit 1
 fi
 
-# Generate the portal run id:
-# 1. If --input-data provides engineParameters.outputUri, extract the portalRunId from it
-# 2. Otherwise use --portal-run-id if provided
-# 3. Otherwise auto-generate
-if [[ -z "${portal_run_id:-}" && -n "${INPUT_DATA_FILE:-}" ]]; then
-  extracted_portal_run_id="$( \
-    jq --raw-output \
-      '
-        .engineParameters.outputUri //
-        empty |
-        rtrimstr("/") |
-        split("/")[-1]
-      ' \
-      "${INPUT_DATA_FILE}" 2>/dev/null || true \
-  )"
-  if [[ -n "${extracted_portal_run_id}" ]]; then
-    portal_run_id="${extracted_portal_run_id}"
-    echo_stderr "Using portal run ID from input data engineParameters.outputUri: ${portal_run_id}"
-  fi
-fi
-portal_run_id="${portal_run_id:-$(generate_portal_run_id)}"
+# Generate the portal run id
+portal_run_id="$(generate_portal_run_id)"
 echo_stderr "Portal Run ID: ${portal_run_id}"
 
 # Get the workflow object

--- a/docs/operation/SOP/PM.SH.1/generate-WRU-draft.sh
+++ b/docs/operation/SOP/PM.SH.1/generate-WRU-draft.sh
@@ -87,7 +87,7 @@ Input data note:
 The populate draft data service will try to auto-populate inputs based on the information it already has.
 --input-data can be used in two ways:
 
-1. Partial override — steer populateDraftData to use a specific upstream analysis
+1. Partial override - steer populateDraftData to use a specific upstream analysis
    (e.g. when two dragen runs exist and you want a particular one):
 {
   \"inputs\": {
@@ -95,7 +95,7 @@ The populate draft data service will try to auto-populate inputs based on the in
   }
 }
 
-2. Full schema bypass — skip populateDraftData entirely by providing a payload that
+2. Full schema bypass - skip populateDraftData entirely by providing a payload that
    satisfies the complete-data-draft-schema.json (tags + inputs + engineParameters).
    populateDraftData validates the payload first; if it is already complete it exits
    immediately without performing any lookups (including the fastq RGID lookup).

--- a/docs/operation/SOP/PM.SH.1/generate-WRU-draft.sh
+++ b/docs/operation/SOP/PM.SH.1/generate-WRU-draft.sh
@@ -102,19 +102,17 @@ The populate draft data service will try to auto-populate inputs based on the in
    Use this when libraries have no fastq sets registered in the metadata service
    (e.g. restarting in dev from prod upstream runs where raw data does not exist in dev).
 
-   Generate a portalRunId first, embed it in the engineParameters URIs, then pass
-   the file to --input-data. The script extracts the portalRunId automatically from
-   engineParameters.outputUri so no extra flags are needed:
+   Provide tags, inputs, and the ICA identifiers (projectId + pipelineId) in --input-data,
+   and use the prefix flags for the URIs. The script merges both, generating the portalRunId
+   automatically:
 
-   PORTAL_RUN_ID=\"\$(date -u +'%Y%m%d')\$(openssl rand -hex 4)\"
-   # build input_data.json with all schema fields and \$PORTAL_RUN_ID in URIs, then:
    bash generate-WRU-draft.sh tumor_lib normal_lib \\
-     --comment 'Restart - pre-populated inputs' \\
+     --comment 'Restart in dev - pre-populated inputs' \\
      --input-data input_data.json \\
+     --output-uri-prefix s3://.../analysis/sash/ \\
+     --logs-uri-prefix s3://.../logs/sash/ \\
+     --cache-uri-prefix s3://.../cache/sash/ \\
      --workflow-version <version> --code-version <code>
-
-   Note: do not pass --output-uri-prefix/--logs-uri-prefix/--cache-uri-prefix when
-   using this pattern, as those flags would override the URIs from --input-data.
 
 Positional arguments:
   library_id:   One or more library IDs to link to the WorkflowRunUpdate event.

--- a/docs/operation/SOP/PM.SH.1/generate-WRU-draft.sh
+++ b/docs/operation/SOP/PM.SH.1/generate-WRU-draft.sh
@@ -113,9 +113,9 @@ Keyword arguments:
                                                            This might be used to explicitly set input files
                                                            See input data note for more information.
   --portal-run-id=<portal_run_id>              (Optional) Override the auto-generated portal run ID.
-                                                           Use with --input-data when providing a complete payload
-                                                           (tags + inputs + engineParameters) to bypass populateDraftData.
-                                                           The engineParameters URIs in the input-data file must use this same ID.
+                                                           If --input-data contains engineParameters.outputUri, the
+                                                           portal run ID is extracted from it automatically and this
+                                                           flag is not needed.
 
 Environment:
   PORTAL_TOKEN: (Required) Your personal portal token from https://portal.${hostname}/
@@ -630,9 +630,28 @@ if ! email_address="$(get_email_from_portal_token)"; then
   exit 1
 fi
 
-# Generate the portal run id (use provided value if set via --portal-run-id)
+# Generate the portal run id:
+# 1. If --input-data provides engineParameters.outputUri, extract the portalRunId from it
+# 2. Otherwise use --portal-run-id if provided
+# 3. Otherwise auto-generate
+if [[ -z "${portal_run_id:-}" && -n "${INPUT_DATA_FILE:-}" ]]; then
+  extracted_portal_run_id="$( \
+    jq --raw-output \
+      '
+        .engineParameters.outputUri //
+        empty |
+        rtrimstr("/") |
+        split("/")[-1]
+      ' \
+      "${INPUT_DATA_FILE}" 2>/dev/null || true \
+  )"
+  if [[ -n "${extracted_portal_run_id}" ]]; then
+    portal_run_id="${extracted_portal_run_id}"
+    echo_stderr "Using portal run ID from input data engineParameters.outputUri: ${portal_run_id}"
+  fi
+fi
 portal_run_id="${portal_run_id:-$(generate_portal_run_id)}"
-echo_stderr "Generated Portal Run ID: ${portal_run_id}"
+echo_stderr "Portal Run ID: ${portal_run_id}"
 
 # Get the workflow object
 workflow="$( \

--- a/docs/operation/SOP/PM.SH.1/generate-WRU-draft.sh
+++ b/docs/operation/SOP/PM.SH.1/generate-WRU-draft.sh
@@ -26,7 +26,7 @@ PAYLOAD_VERSION="2025.08.05"
 ANALYSIS_STORAGE_SIZE="SMALL"
 
 # SOP constants
-SOP_VERSION="2026.03.05"
+SOP_VERSION="2026.04.17"
 SOP_ID="PM.SH.1"
 GITHUB_REPO="OrcaBus/service-sash-pipeline-manager"
 THIS_SCRIPT_PATH="docs/operation/SOP/${SOP_ID}/generate-WRU-draft.sh"
@@ -69,6 +69,7 @@ generate-WRU-draft.sh (library_id)...
                       [--workflow-version <workflow_version>]
                       [--code-version <code_version>]
                       [--input-data <input_data_path>]
+                      [--portal-run-id <portal_run_id>]
 
 Description:
 Run this script to generate a draft WorkflowRunUpdate event for the specified library IDs.
@@ -111,6 +112,10 @@ Keyword arguments:
   --input-data=<input_data_file>                (Optional) Add existing input data to the data section of the payload.
                                                            This might be used to explicitly set input files
                                                            See input data note for more information.
+  --portal-run-id=<portal_run_id>              (Optional) Override the auto-generated portal run ID.
+                                                           Use with --input-data when providing a complete payload
+                                                           (tags + inputs + engineParameters) to bypass populateDraftData.
+                                                           The engineParameters URIs in the input-data file must use this same ID.
 
 Environment:
   PORTAL_TOKEN: (Required) Your personal portal token from https://portal.${hostname}/
@@ -516,6 +521,15 @@ while [[ $# -gt 0 ]]; do
       INPUT_DATA_FILE="${1#*=}"
       shift
       ;;
+    # Portal run id override
+    --portal-run-id)
+      portal_run_id="$2"
+      shift 2
+      ;;
+    --portal-run-id=*)
+      portal_run_id="${1#*=}"
+      shift
+      ;;
     # Positional arguments (library IDs)
     *)
       LIBRARY_ID_ARRAY+=("$1")
@@ -616,8 +630,8 @@ if ! email_address="$(get_email_from_portal_token)"; then
   exit 1
 fi
 
-# Generate the portal run id
-portal_run_id="$(generate_portal_run_id)"
+# Generate the portal run id (use provided value if set via --portal-run-id)
+portal_run_id="${portal_run_id:-$(generate_portal_run_id)}"
 echo_stderr "Generated Portal Run ID: ${portal_run_id}"
 
 # Get the workflow object

--- a/docs/operation/SOP/PM.SH.1/generate-WRU-draft.sh
+++ b/docs/operation/SOP/PM.SH.1/generate-WRU-draft.sh
@@ -85,13 +85,36 @@ The output uri prefix, cache uri and logs uri prefixes must be set to a location
 
 Input data note:
 The populate draft data service will try to auto-populate inputs based on the information it already has.
-This may have unintended consequences if there exists two downstream analyses and you want inputs from one specific analysis.
-In this circumstance it is recommended to use the '--input-data <json_file>' to generate an existing data object to populate, for example:
+--input-data can be used in two ways:
+
+1. Partial override — steer populateDraftData to use a specific upstream analysis
+   (e.g. when two dragen runs exist and you want a particular one):
 {
   \"inputs\": {
     \"dragenSomaticDir\": \"s3://path/to/specific/dragen-somatic-directory/\"
   }
 }
+
+2. Full schema bypass — skip populateDraftData entirely by providing a payload that
+   satisfies the complete-data-draft-schema.json (tags + inputs + engineParameters).
+   populateDraftData validates the payload first; if it is already complete it exits
+   immediately without performing any lookups (including the fastq RGID lookup).
+   Use this when libraries have no fastq sets registered in the metadata service
+   (e.g. restarting in dev from prod upstream runs).
+
+   Generate a portalRunId first, embed it in the engineParameters URIs, then pass
+   the file to --input-data. The script extracts the portalRunId automatically from
+   engineParameters.outputUri so no extra flags are needed:
+
+   PORTAL_RUN_ID=\"\$(date -u +'%Y%m%d')\$(openssl rand -hex 4)\"
+   # build input_data.json with all schema fields and \$PORTAL_RUN_ID in URIs, then:
+   bash generate-WRU-draft.sh tumor_lib normal_lib \\
+     --comment 'Restart - bypass fastq lookup' \\
+     --input-data input_data.json \\
+     --workflow-version <version> --code-version <code>
+
+   Note: do not pass --output-uri-prefix/--logs-uri-prefix/--cache-uri-prefix when
+   using this pattern, as those flags would override the URIs from --input-data.
 
 Positional arguments:
   library_id:   One or more library IDs to link to the WorkflowRunUpdate event.


### PR DESCRIPTION
## Summary

Documents the recommended pattern for restarting sash in dev when libraries have no fastq sets in the metadata service.

## Context

In dev, libraries from prod upstream runs (dragen, oncoanalyser) have no fastq sets registered in the dev metadata service - the raw sequencing data does not exist in dev, only derived analysis outputs. This causes `populateDraftData` to always fail at `getFastqRgidsFromLibrary` with:

```
ValueError: Expected exactly one current fastq set for library <id>, found 0
```

`populateDraftData` validates the payload first: if it already satisfies `complete-data-draft-schema.json` (`tags` + `inputs` + `engineParameters`), it exits immediately without performing any lookups.

The recommended pattern is to provide `tags`, `inputs`, and the ICA identifiers (`projectId` + `pipelineId`) in `--input-data`, and use the prefix flags for the URIs. The script merges both and auto-generates the portalRunId.