### PR TITLE
Onboard 0.6.4 workflow version config

### DIFF
--- a/infrastructure/stage/constants.ts
+++ b/infrastructure/stage/constants.ts
@@ -33,7 +33,7 @@ export const WORKFLOW_VERSION_TO_DEFAULT_ICAV2_PIPELINE_ID_MAP: Record<
   '0.6.1': '5c8d2267-73bc-4923-83ec-15fe1aa6aed9',
   '0.6.2': '5865b1f2-ce78-4fe7-a630-24cb6a55fb88',
   '0.6.3': '5b4060de-5e43-4aa6-b408-f51537d43c65',
-  '0.6.4-rc': '51f0d1dc-be92-4a5e-9a8a-ad8d44a6431c', // Available in dev only
+  '0.6.4': '51f0d1dc-be92-4a5e-9a8a-ad8d44a6431c', // Available in dev only
   '0.7.0': 'b0e1873d-2266-489c-a5d7-341c4fde96a4',
 };
 
@@ -43,8 +43,7 @@ export const WORKFLOW_VERSION_TO_SASH_REFERENCE_PATHS_MAP: Record<WorkflowVersio
   '0.6.1': 's3://reference-data-503977275616-ap-southeast-2/refdata/sash/0.6.1/',
   '0.6.2': 's3://reference-data-503977275616-ap-southeast-2/refdata/sash/0.6.1/',
   '0.6.3': 's3://reference-data-503977275616-ap-southeast-2/refdata/sash/0.6.1/',
-  // FIXME - to confirm if reference data differs
-  '0.6.4-rc': 's3://reference-data-503977275616-ap-southeast-2/refdata/sash/0.6.1/',
+  '0.6.4': 's3://reference-data-503977275616-ap-southeast-2/refdata/sash/0.6.4/', // Available in dev only
   // Add pcgr/20250314/ and pcgr/VEP/ for 0.7.0
   '0.7.0': 's3://reference-data-503977275616-ap-southeast-2/refdata/sash/0.7.0/',
 };

--- a/infrastructure/stage/constants.ts
+++ b/infrastructure/stage/constants.ts
@@ -33,6 +33,7 @@ export const WORKFLOW_VERSION_TO_DEFAULT_ICAV2_PIPELINE_ID_MAP: Record<
   '0.6.1': '5c8d2267-73bc-4923-83ec-15fe1aa6aed9',
   '0.6.2': '5865b1f2-ce78-4fe7-a630-24cb6a55fb88',
   '0.6.3': '5b4060de-5e43-4aa6-b408-f51537d43c65',
+  '0.6.4-rc': '51f0d1dc-be92-4a5e-9a8a-ad8d44a6431c', // Available in dev only
   '0.7.0': 'b0e1873d-2266-489c-a5d7-341c4fde96a4',
 };
 
@@ -42,6 +43,8 @@ export const WORKFLOW_VERSION_TO_SASH_REFERENCE_PATHS_MAP: Record<WorkflowVersio
   '0.6.1': 's3://reference-data-503977275616-ap-southeast-2/refdata/sash/0.6.1/',
   '0.6.2': 's3://reference-data-503977275616-ap-southeast-2/refdata/sash/0.6.1/',
   '0.6.3': 's3://reference-data-503977275616-ap-southeast-2/refdata/sash/0.6.1/',
+  // FIXME - to confirm if reference data differs
+  '0.6.4-rc': 's3://reference-data-503977275616-ap-southeast-2/refdata/sash/0.6.1/',
   // Add pcgr/20250314/ and pcgr/VEP/ for 0.7.0
   '0.7.0': 's3://reference-data-503977275616-ap-southeast-2/refdata/sash/0.7.0/',
 };

--- a/infrastructure/stage/interfaces.ts
+++ b/infrastructure/stage/interfaces.ts
@@ -34,4 +34,4 @@ export interface StatelessApplicationStackConfig {
 }
 
 /* Set versions */
-export type WorkflowVersionType = '0.6.0' | '0.6.1' | '0.6.2' | '0.6.3' | '0.7.0';
+export type WorkflowVersionType = '0.6.0' | '0.6.1' | '0.6.2' | '0.6.3' | '0.6.4-rc' | '0.7.0';

--- a/infrastructure/stage/interfaces.ts
+++ b/infrastructure/stage/interfaces.ts
@@ -34,4 +34,4 @@ export interface StatelessApplicationStackConfig {
 }
 
 /* Set versions */
-export type WorkflowVersionType = '0.6.0' | '0.6.1' | '0.6.2' | '0.6.3' | '0.6.4-rc' | '0.7.0';
+export type WorkflowVersionType = '0.6.0' | '0.6.1' | '0.6.2' | '0.6.3' | '0.6.4' | '0.7.0';


### PR DESCRIPTION
*   Added `0.6.4` to the `WorkflowVersionType` for new workflows.
*   Mapped the `0.6.4` workflow to its default ICAv2 pipeline ID in constants.
*   Configured `0.6.4` with default SASH reference paths.
*   Included comments noting dev-only availability and a `FIXME` for reference data.