### PR TITLE
Refines project folder URI validation

### DIFF
--- a/app/lambdas/post_schema_validation_py/post_schema_validation.py
+++ b/app/lambdas/post_schema_validation_py/post_schema_validation.py
@@ -154,12 +154,17 @@ def validate_inputs(
     # Or externally mounted data uris (e.g. s3://reference-data-bucket/...)
     data_uris = list(filter(
         lambda uri_iter_: (
-            # Doesn't belong to test-data bucket
-            # Doesn't belong to the project bucket
+            # Doesn't
+            #   * belong to test-data bucket
+            #   * belong to the project bucket
+            #   * A uri that belongs to the project and is a file (this is validated above)
             not (
                 uri_iter_.startswith(f"s3://{environ[TEST_BUCKET_ENV_VAR]}/") or
                 uri_iter_.startswith(f"s3://{environ[REF_DATA_BUCKET_ENV_VAR]}/") or
-                uri_iter_.startswith(project_prefix)
+                (
+                    uri_iter_.startswith(project_prefix) and
+                    not uri_iter_.endswith("/")
+                )
             )
         ),
         data_uris


### PR DESCRIPTION
Refines the validation logic for `data_uris` by correcting the filtering condition for project-specific URIs. Previously, all URIs starting with the project prefix were excluded, including folders. This update ensures that only file URIs within the project prefix are excluded, allowing project-related folders to proceed for proper validation.