### PR TITLE
fix: guard get_s3_key_prefix_by_project_id against ApiException and None

### DIFF
--- a/app/lambdas/post_schema_validation_py/post_schema_validation.py
+++ b/app/lambdas/post_schema_validation_py/post_schema_validation.py
@@ -319,14 +319,25 @@ def handler(event, context) -> Dict[str, bool]:
         )
         return {"isValid": False}
 
-    project_prefix = get_s3_key_prefix_by_project_id(project_id)
+    try:
+        project_prefix = get_s3_key_prefix_by_project_id(project_id)
+    except ApiException:
+        add_comment_to_workflow_run(
+            workflow_run_orcabus_id=workflow_run_id,
+            comment=_format_comment_with_arn(
+                f"Post schema validation failed: cannot resolve S3 key prefix for projectId '{project_id}'",
+                execution_arn
+            ),
+            author=COMMENT_AUTHOR
+        )
+        return {"isValid": False}
 
     if project_prefix is None:
         # Write failure comment
         add_comment_to_workflow_run(
             workflow_run_orcabus_id=workflow_run_id,
             comment=_format_comment_with_arn(
-                f"Post schema validation failed: Could not get the ICA project prefix for project {project_id}",
+                f"Post schema validation failed: no S3 key prefix configured for projectId '{project_id}'",
                 execution_arn
             ),
             author=COMMENT_AUTHOR


### PR DESCRIPTION
## Summary

Adds defensive handling around `get_s3_key_prefix_by_project_id` in the `post_schema_validation` lambda.

The wrapica function can:
1. **Raise `ApiException`** — if the ICAv2 API call fails (network issues, auth problems, invalid project)
2. **Return `None`** — if the project has no storage configuration

Previously only the `None` case was handled. Now both failure modes are caught, a descriptive comment is written to the workflow run record, and `{"isValid": false}` is returned gracefully.

## Related PRs

This fix is being applied consistently across all pipeline manager services:
- OrcaBus/service-arriba-wgts-rna-pipeline-manager
- OrcaBus/service-bclconvert-interop-qc-pipeline-manager
- OrcaBus/service-dragen-tso500-ctdna-pipeline-manager
- OrcaBus/service-dragen-wgts-dna-pipeline-manager
- OrcaBus/service-dragen-wgts-rna-pipeline-manager
- OrcaBus/service-oncoanalyser-wgts-dna-pipeline-manager
- OrcaBus/service-oncoanalyser-wgts-rna-pipeline-manager
- OrcaBus/service-sash-pipeline-manager